### PR TITLE
Enable detailed search parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # portal
+
+Simple script for searching [p-portal](https://www.p-portal.go.jp) with
+optional parameters.
+
+```
+python portal_search.py --case "入札" --start-from 2024/06/01 --start-to 2024/06/30
+```


### PR DESCRIPTION
## Summary
- extend `portal_search.py` to accept case name and public start date range
- update README with example usage

## Testing
- `python3 -m py_compile portal_search.py`
- `python portal_search.py --case "総合" --start-from 2024/06/01 | head`

------
https://chatgpt.com/codex/tasks/task_e_686792cc1d188321aa46c142e8dae48a