### PR TITLE
Update search script defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # portal
 
-Simple script for searching [p-portal](https://www.p-portal.go.jp) with
-optional parameters.
+Simple script for searching [p-portal](https://www.p-portal.go.jp).
+If no dates are provided, the script searches only entries added today.
 
 ```
 python portal_search.py --case "入札" --start-from 2024/06/01 --start-to 2024/06/30
+
+# search today's entries
+python portal_search.py --case "入札"
 ```


### PR DESCRIPTION
## Summary
- default "公開開始日" to today's date
- return the search results page URL
- clarify README usage

## Testing
- `python portal_search.py --case "テスト"`
- `python -m py_compile portal_search.py`


------
https://chatgpt.com/codex/tasks/task_e_686797ac8f548321ae1ad4d99f9edacf