### PR TITLE
Add daily workflow

### DIFF
--- a/.github/workflows/run_daily.yml
+++ b/.github/workflows/run_daily.yml
@@ -1,0 +1,23 @@
+name: Run portal search daily
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install requests beautifulsoup4
+      - name: Run portal search
+        run: |
+          python portal_search.py


### PR DESCRIPTION
## Summary
- schedule GitHub Action to run portal search once per day

## Testing
- `python portal_search.py --case "入札" --start-from 2024/06/01 --start-to 2024/06/30 | head`

------
https://chatgpt.com/codex/tasks/task_e_68679dd4ca3483218209f0549015796a