### PR TITLE
Support multi-keyword search

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,7 @@ python portal_search.py --case "入札" --start-from 2024/06/01 --start-to 2024/
 
 # search today's entries
 python portal_search.py --case "入札"
+
+# search multiple keywords and merge results
+python portal_search.py --cases データ システム サーバ web
 ```


### PR DESCRIPTION
## Summary
- allow passing multiple keywords and deduplicate results
- document new `--cases` option

## Testing
- `python -m py_compile portal_search.py`
- `pip install requests beautifulsoup4`
- `python portal_search.py --cases データ システム サーバ web`

------
https://chatgpt.com/codex/tasks/task_e_686d25ec315c832187b4823e6aa0190b